### PR TITLE
less layers for the Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,15 @@
 FROM node:12-slim
-USER node
-RUN mkdir /home/node/kmdr.sh
+
+COPY ./ /home/node/kmdr.sh
+
 WORKDIR /home/node/kmdr.sh
-COPY ./ ./
-ENV PATH=/home/node/.npm-global/bin:$PATH
-ENV NPM_CONFIG_PREFIX=/home/node/.npm-global
-RUN npm install 
-RUN npm run build
-RUN npm link
-RUN echo 'PS1="\\$\[$(tput sgr0)\] "' >> /home/node/.bashrc
+
+ENV PATH=/home/node/.npm-global/bin:$PATH \
+    NPM_CONFIG_PREFIX=/home/node/.npm-global
+
+RUN npm install \ 
+&&  npm run build \
+&&  npm link \
+&&  echo 'PS1="\\$\[$(tput sgr0)\] "' >> /home/node/.bashrc
+
+ENTRYPOINT [ "kmdr", "explain" ]


### PR DESCRIPTION
Hi, I mainly changed 3 things:
1. removed USER node (is not necessary here)
2. binding the different layers together.
3. added the entry point

This makes it possible to directly start the input of the command with the command:
`docker run --rm -ti kmdr` (where kmdr is the name of the image)