### PR TITLE
Use --no-deprecation (node)

### DIFF
--- a/src/bin.ts
+++ b/src/bin.ts
@@ -1,4 +1,4 @@
-#!/usr/bin/env node
+#!/usr/bin/env node --no-deprecation
 
 import KMDR from "./kmdr";
 const kmdr = new KMDR();


### PR DESCRIPTION
Hide node deprecation warnings until I figure out how to remove them