### PR TITLE
Remove --no-deprecation flag

### DIFF
--- a/src/bin.ts
+++ b/src/bin.ts
@@ -1,4 +1,4 @@
-#!/usr/bin/env node --no-deprecation
+#!/usr/bin/env node
 
 import KMDR from "./kmdr";
 const kmdr = new KMDR();

--- a/src/client.ts
+++ b/src/client.ts
@@ -45,7 +45,7 @@ export default class Client {
       const proxy: ProxyOptions = {
         host: parsedProxyUrl.hostname || "",
         port: parseInt(parsedProxyUrl.port || "", 10),
-        proxyAuth: parsedProxyUrl.auth,
+        proxyAuth: parsedProxyUrl.auth ?? undefined,
       };
 
       let httpsAgent: Agent;


### PR DESCRIPTION
In some unix-like OS's, we can't pass multiple
options/arguments on shebang lines and it breaks
the load mechanism for Node.js.

Removing the flag until we find a way to hide
deprecation messages safely.

Fixes #38 